### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/cd-docker-demo.yml
+++ b/.github/workflows/cd-docker-demo.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ env.REGISTRY }}/${{ env.ACR_REPO }}
         username: ${{ secrets.ESQUIO_DOCKER_USERNAME }}

--- a/.github/workflows/cd-docker-internal-demo.yml
+++ b/.github/workflows/cd-docker-internal-demo.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry internal demo app
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ env.REGISTRY }}/${{ env.ACR_REPO_APP }}
         username: ${{ secrets.ESQUIO_DOCKER_USERNAME }}
@@ -25,7 +25,7 @@ jobs:
         tags: "latest,${{ env.TAG }}"
 
     - name: Publish to Registry internal demo ui
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ env.REGISTRY }}/${{ env.ACR_REPO_UI }}
         username: ${{ secrets.ESQUIO_DOCKER_USERNAME }}

--- a/.github/workflows/cd-docker-ui-preview.yml
+++ b/.github/workflows/cd-docker-ui-preview.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ env.ESQUIO_REPO }}/${{ env.IMAGE_NAME }}
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/cd-docker-ui.yml
+++ b/.github/workflows/cd-docker-ui.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ env.ESQUIO_REPO }}/${{ env.IMAGE_NAME }}
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore